### PR TITLE
Don't repeat class name template arguements

It prevents mistakes and it simplifies the readability of the code.

### DIFF
--- a/include/rfl/Binary.hpp
+++ b/include/rfl/Binary.hpp
@@ -26,9 +26,9 @@ struct Binary {
 
   Binary(const Type& _value) : value_(_value) {}
 
-  Binary(Binary<T>&& _other) noexcept = default;
+  Binary(Binary&& _other) noexcept = default;
 
-  Binary(const Binary<T>& _other) = default;
+  Binary(const Binary& _other) = default;
 
   template <class U>
   Binary(const Binary<U>& _other) : value_(_other.get()) {}
@@ -77,10 +77,10 @@ struct Binary {
   }
 
   /// Assigns the underlying object.
-  Binary<T>& operator=(const Binary<T>& _other) = default;
+  Binary& operator=(const Binary<T>& _other) = default;
 
   /// Assigns the underlying object.
-  Binary<T>& operator=(Binary<T>&& _other) = default;
+  Binary& operator=(Binary<T>&& _other) = default;
 
   /// Assigns the underlying object.
   template <class U>

--- a/include/rfl/Box.hpp
+++ b/include/rfl/Box.hpp
@@ -29,31 +29,31 @@ class Box {
   /// The only way of creating new boxes is
   /// Box<T>::make(...).
   template <class... Args>
-  static Box<T, C> make(Args&&... _args) {
-    return Box<T, C>(std::make_unique<T>(std::forward<Args>(_args)...));
+  static Box make(Args&&... _args) {
+    return Box(std::make_unique<T>(std::forward<Args>(_args)...));
   }
 
   /// You can generate them from unique_ptrs as well, in which case it will
   /// return an Error, if the unique_ptr is not set.
-  static Result<Box<T, C>> make(std::unique_ptr<T>&& _ptr) {
+  static Result<Box> make(std::unique_ptr<T>&& _ptr) {
     if (!_ptr) {
       return error("std::unique_ptr was a nullptr.");
     }
-    return Box<T, C>(std::move(_ptr));
+    return Box(std::move(_ptr));
   }
 
   Box() : ptr_(std::make_unique<T>()) {}
 
   /// Copy constructor if copyable
-  Box(const Box<T, C>& _other) requires (C == Copyability::COPYABLE)
+  Box(const Box& _other) requires (C == Copyability::COPYABLE)
   {
     ptr_ = std::make_unique<T>(*_other);
   }
 
   /// Copy constructor if not copyable
-  Box(const Box<T, C>& _other) requires (C == Copyability::NON_COPYABLE) = delete;
+  Box(const Box& _other) requires (C == Copyability::NON_COPYABLE) = delete;
 
-  Box(Box<T, C>&& _other) = default;
+  Box(Box&& _other) = default;
 
   template <class U, Copyability C2>
   Box(Box<U, C2>&& _other) noexcept
@@ -65,7 +65,7 @@ class Box {
   T* get() const { return ptr_.get(); }
 
   /// Copy assignment operator if copyable
-  Box<T, C>& operator=(const Box<T>& other) requires (C == Copyability::COPYABLE) {
+  Box& operator=(const Box<T>& other) requires (C == Copyability::COPYABLE) {
     if(this != &other) {
       ptr_ = std::make_unique<T>(*other);
     }
@@ -73,14 +73,14 @@ class Box {
   }
 
   /// Copy assignment operator if not copyable
-  Box<T, C>& operator=(const Box<T>& _other) requires (C == Copyability::NON_COPYABLE)  = delete;
+  Box& operator=(const Box& _other) requires (C == Copyability::NON_COPYABLE)  = delete;
 
   /// Move assignment operator
-  Box<T, C>& operator=(Box<T, C>&& _other) noexcept = default;
+  Box& operator=(Box&& _other) noexcept = default;
 
   /// Move assignment operator
   template <class U>
-  Box<T, C>& operator=(Box<U>&& _other) noexcept {
+  Box& operator=(Box<U>&& _other) noexcept {
     ptr_ = std::forward<std::unique_ptr<U>>(_other.ptr());
     return *this;
   }

--- a/include/rfl/Description.hpp
+++ b/include/rfl/Description.hpp
@@ -31,9 +31,9 @@ struct Description {
 
   Description(Type&& _value) noexcept : value_(std::move(_value)) {}
 
-  Description(Description<_description, T>&& _field) noexcept = default;
+  Description(Description&& _field) noexcept = default;
 
-  Description(const Description<_description, Type>& _field) = default;
+  Description(const Description& _field) = default;
 
   template <class U>
   Description(const Description<_description, U>& _field)
@@ -105,12 +105,12 @@ struct Description {
   }
 
   /// Assigns the underlying object.
-  Description<_description, T>& operator=(
-      const Description<_description, T>& _field) = default;
+  Description& operator=(
+      const Description& _field) = default;
 
   /// Assigns the underlying object.
-  Description<_description, T>& operator=(
-      Description<_description, T>&& _field) = default;
+  Description& operator=(
+      Description&& _field) = default;
 
   /// Assigns the underlying object.
   template <class U>

--- a/include/rfl/Field.hpp
+++ b/include/rfl/Field.hpp
@@ -29,9 +29,9 @@ struct Field {
 
   Field(Type&& _value) noexcept : value_(std::move(_value)) {}
 
-  Field(Field<_name, T>&& _field) noexcept = default;
+  Field(Field&& _field) noexcept = default;
 
-  Field(const Field<_name, T>& _field) = default;
+  Field(const Field& _field) = default;
 
   template <class U>
   Field(const Field<_name, U>& _field) : value_(_field.get()) {}
@@ -104,10 +104,10 @@ struct Field {
   }
 
   /// Assigns the underlying object.
-  Field<_name, T>& operator=(const Field<_name, T>& _field) = default;
+  Field& operator=(const Field& _field) = default;
 
   /// Assigns the underlying object.
-  Field<_name, T>& operator=(Field<_name, T>&& _field) = default;
+  Field& operator=(Field&& _field) = default;
 
   /// Assigns the underlying object.
   template <class U>

--- a/include/rfl/Flatten.hpp
+++ b/include/rfl/Flatten.hpp
@@ -21,9 +21,9 @@ struct Flatten {
 
   Flatten(Type&& _value) noexcept : value_(std::forward<Type>(_value)) {}
 
-  Flatten(const Flatten<T>& _f) = default;
+  Flatten(const Flatten& _f) = default;
 
-  Flatten(Flatten<T>&& _f) noexcept = default;
+  Flatten(Flatten&& _f) noexcept = default;
 
   template <class U>
   Flatten(const Flatten<U>& _f) : value_(_f.get()) {}
@@ -54,13 +54,13 @@ struct Flatten {
   const Type& operator()() const { return value_; }
 
   /// Assigns the underlying object.
-  Flatten<T>& operator=(const T& _value) {
+  Flatten& operator=(const T& _value) {
     value_ = _value;
     return *this;
   }
 
   /// Assigns the underlying object.
-  Flatten<T>& operator=(T&& _value) {
+  Flatten& operator=(T&& _value) {
     value_ = std::forward<Type>(_value);
     return *this;
   }
@@ -68,27 +68,27 @@ struct Flatten {
   /// Assigns the underlying object.
   template <class U, typename std::enable_if<std::is_convertible_v<U, Type>,
                                              bool>::type = true>
-  Flatten<T>& operator=(const U& _value) {
+  Flatten& operator=(const U& _value) {
     value_ = _value;
     return *this;
   }
 
   /// Assigns the underlying object.
-  Flatten<T>& operator=(const Flatten<T>& _f) = default;
+  Flatten& operator=(const Flatten& _f) = default;
 
   /// Assigns the underlying object.
-  Flatten<T>& operator=(Flatten<T>&& _f) = default;
+  Flatten& operator=(Flatten&& _f) = default;
 
   /// Assigns the underlying object.
   template <class U>
-  Flatten<T>& operator=(const Flatten<U>& _f) {
+  Flatten& operator=(const Flatten<U>& _f) {
     value_ = _f.get();
     return *this;
   }
 
   /// Assigns the underlying object.
   template <class U>
-  Flatten<T>& operator=(Flatten<U>&& _f) {
+  Flatten& operator=(Flatten<U>&& _f) {
     value_ = std::forward<U>(_f);
     return *this;
   }

--- a/include/rfl/Tuple.hpp
+++ b/include/rfl/Tuple.hpp
@@ -48,9 +48,9 @@ class Tuple {
 
   Tuple() : Tuple(Types()...) {}
 
-  Tuple(const Tuple<Types...>& _other) { copy_from_other(_other, seq_); }
+  Tuple(const Tuple& _other) { copy_from_other(_other, seq_); }
 
-  Tuple(Tuple<Types...>&& _other) noexcept {
+  Tuple(Tuple&& _other) noexcept {
     move_from_other(std::move(_other), seq_);
   }
 
@@ -71,18 +71,18 @@ class Tuple {
   }
 
   /// Assigns the underlying object.
-  Tuple<Types...>& operator=(const Tuple<Types...>& _other) {
+  Tuple& operator=(const Tuple& _other) {
     if (this == &_other) {
       return *this;
     }
-    auto temp = Tuple<Types...>(_other);
+    auto temp = Tuple(_other);
     destroy_if_necessary(seq_);
     move_from_other(std::move(temp), seq_);
     return *this;
   }
 
   /// Assigns the underlying object.
-  Tuple<Types...>& operator=(Tuple<Types...>&& _other) noexcept {
+  Tuple& operator=(Tuple&& _other) noexcept {
     if (this == &_other) {
       return *this;
     }
@@ -127,7 +127,7 @@ class Tuple {
 
  private:
   template <int... _is>
-  void copy_from_other(const Tuple<Types...>& _other,
+  void copy_from_other(const Tuple& _other,
                        std::integer_sequence<int, _is...>) {
     const auto copy_one = [this]<int _i>(const auto& _other,
                                          std::integral_constant<int, _i>) {
@@ -161,7 +161,7 @@ class Tuple {
   }
 
   template <int... _is>
-  void move_from_other(Tuple<Types...>&& _other,
+  void move_from_other(Tuple&& _other,
                        std::integer_sequence<int, _is...>) {
     const auto move_one = [this]<int _i>(auto&& _other,
                                          std::integral_constant<int, _i>) {

--- a/include/rfl/Validator.hpp
+++ b/include/rfl/Validator.hpp
@@ -21,9 +21,9 @@ struct Validator {
       std::conditional_t<sizeof...(Vs) == 0, V, AllOf<V, Vs...>>;
 
   /// Exception-free validation.
-  static Result<Validator<T, V, Vs...>> from_value(const T& _value) noexcept {
+  static Result<Validator> from_value(const T& _value) noexcept {
     try {
-      return Validator<T, V, Vs...>(_value);
+      return Validator(_value);
     } catch (std::exception& e) {
       return error(e.what());
     }
@@ -31,9 +31,9 @@ struct Validator {
 
   Validator() : value_(ValidationType::validate(T()).value()) {}
 
-  Validator(Validator<T, V, Vs...>&& _other) noexcept = default;
+  Validator(Validator&& _other) noexcept = default;
 
-  Validator(const Validator<T, V, Vs...>& _other) = default;
+  Validator(const Validator& _other) = default;
 
   Validator(T&& _value) : value_(ValidationType::validate(_value).value()) {}
 
@@ -65,11 +65,11 @@ struct Validator {
   }
 
   /// Assigns the underlying object.
-  Validator<T, V, Vs...>& operator=(const Validator<T, V, Vs...>& _other) =
+  Validator& operator=(const Validator& _other) =
       default;
 
   /// Assigns the underlying object.
-  Validator<T, V, Vs...>& operator=(Validator<T, V, Vs...>&& _other) noexcept =
+  Validator& operator=(Validator&& _other) noexcept =
       default;
 
   /// Assigns the underlying object.
@@ -89,7 +89,7 @@ struct Validator {
   }
 
   /// Equality operator other Validators.
-  bool operator==(const Validator<T, V, Vs...>& _other) const {
+  bool operator==(const Validator& _other) const {
     return value() == _other.value();
   }
 

--- a/include/rfl/Variant.hpp
+++ b/include/rfl/Variant.hpp
@@ -11,10 +11,10 @@
 
 #include "internal/element_index.hpp"
 #include "internal/nth_element_t.hpp"
+#include "internal/ptr_cast.hpp"
 #include "internal/variant/find_max_size.hpp"
 #include "internal/variant/is_alternative_type.hpp"
 #include "internal/variant/result_t.hpp"
-#include "internal/ptr_cast.hpp"
 
 namespace rfl {
 
@@ -49,12 +49,12 @@ class Variant {
     move_from_type(FirstAlternative());
   }
 
-  Variant(const Variant<AlternativeTypes...>& _other)
+  Variant(const Variant& _other)
       : index_(IndexType()), data_(DataType()) {
     copy_from_other(_other);
   }
 
-  Variant(Variant<AlternativeTypes...>&& _other) noexcept
+  Variant(Variant&& _other) noexcept
       : index_(IndexType()), data_(DataType()) {
     move_from_other(std::move(_other));
   }
@@ -101,8 +101,8 @@ class Variant {
             typename std::enable_if<internal::variant::is_alternative_type<
                                         T, AlternativeTypes...>(),
                                     bool>::type = true>
-  Variant<AlternativeTypes...>& operator=(const T& _t) {
-    auto temp = Variant<AlternativeTypes...>(_t);
+  Variant& operator=(const T& _t) {
+    auto temp = Variant(_t);
     destroy_if_necessary();
     move_from_other(std::move(temp));
     return *this;
@@ -113,27 +113,25 @@ class Variant {
             typename std::enable_if<internal::variant::is_alternative_type<
                                         T, AlternativeTypes...>(),
                                     bool>::type = true>
-  Variant<AlternativeTypes...>& operator=(T&& _t) noexcept {
+  Variant& operator=(T&& _t) noexcept {
     destroy_if_necessary();
     move_from_type(std::forward<T>(_t));
     return *this;
   }
 
   /// Assigns the underlying object.
-  Variant<AlternativeTypes...>& operator=(
-      const Variant<AlternativeTypes...>& _other) {
+  Variant& operator=(const Variant& _other) {
     if (this == &_other) {
       return *this;
     }
-    auto temp = Variant<AlternativeTypes...>(_other);
+    auto temp = Variant(_other);
     destroy_if_necessary();
     move_from_other(std::move(temp));
     return *this;
   }
 
   /// Assigns the underlying object.
-  Variant<AlternativeTypes...>& operator=(
-      Variant<AlternativeTypes...>&& _other) noexcept {
+  Variant& operator=(Variant&& _other) noexcept {
     if (this == &_other) {
       return *this;
     }
@@ -143,11 +141,11 @@ class Variant {
   }
 
   /// Swaps the content with the other variant.
-  void swap(Variant<AlternativeTypes...>& _other) noexcept {
+  void swap(Variant& _other) noexcept {
     if (this == &_other) {
       return;
     }
-    auto temp = Variant<AlternativeTypes...>(std::move(*this));
+    auto temp = Variant(std::move(*this));
     move_from_other(std::move(_other));
     _other = std::move(temp);
   }
@@ -193,7 +191,7 @@ class Variant {
   }
 
  private:
-  void copy_from_other(const Variant<AlternativeTypes...>& _other) {
+  void copy_from_other(const Variant& _other) {
     const auto copy_one = [this](const auto& _t) { this->copy_from_type(_t); };
     _other.visit(copy_one);
   }
@@ -396,11 +394,11 @@ class Variant {
     return *internal::ptr_cast<const CurrentType*>(data_.data());
   }
 
-  void move_from_other(Variant<AlternativeTypes...>&& _other) noexcept {
+  void move_from_other(Variant&& _other) noexcept {
     const auto move_one = [this](auto&& _t) {
       this->move_from_type(std::forward<std::remove_cvref_t<decltype(_t)>>(_t));
     };
-    std::forward<Variant<AlternativeTypes...>>(_other).visit(move_one);
+    std::move(_other).visit(move_one);
   }
 
   template <class T>


### PR DESCRIPTION
Repeating ourselves provides no value in this case it is verbose.